### PR TITLE
Huge PR with a lot of fixes for #18 #19 #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Follow the instruction in [NPM](https://www.npmjs.com/package/homebridge) for th
 -   zone - Zone name
 -   zone_controllers_only_for - A list of zone names for which an accessory is to be created. If no value for this key is provided, then accessories for all available zones are created.
 -   cursor_remote_control - If set to true the remote control will control the cursor for use with on screen display, else it will control the media playback ( true/false ).
+- disable_party_switch - If set to true, a party switch will NOT be created.
+- disable_main_power_switch - If set to true, a main power switch will NOT be created.
 
 ## Basic config.json config
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Follow the instruction in [NPM](https://www.npmjs.com/package/homebridge) for th
 -   zone - Zone name
 -   zone_controllers_only_for - A list of zone names for which an accessory is to be created. If no value for this key is provided, then accessories for all available zones are created.
 -   cursor_remote_control - If set to true the remote control will control the cursor for use with on screen display, else it will control the media playback ( true/false ).
-- disable_party_switch - If set to true, a party switch will NOT be created.
-- disable_main_power_switch - If set to true, a main power switch will NOT be created.
+-   disable_party_switch - If set to true, a party switch will NOT be created.
+-   disable_main_power_switch - If set to true, a main power switch will NOT be created.
 
 ## Basic config.json config
 

--- a/index.js
+++ b/index.js
@@ -645,7 +645,7 @@ YamahaZone.prototype = {
           });
 
         } else {
-          debug("Incrementing Volume by 1 for ", that.zone, v / 10);
+          debug("Incrementing Volume by 1 for ", that.zone);
           yamaha.volumeUp(1, that.zone).then(function(status) {
             debug("Status", that.zone, status);
           });

--- a/index.js
+++ b/index.js
@@ -14,16 +14,18 @@ Configuration Sample:
 
 "use strict";
 
-var Accessory, Service, Characteristic, UUIDGen, hap;
+var Accessory, Service, Characteristic, UUIDGen, hap, CachedConfigFile, cachedConfig;
 // var inherits = require('util').inherits;
 var debug = require('debug')('yamaha-zone-tv');
 var util = require('./lib/util.js');
 var Yamaha = require('yamaha-nodejs');
+var fs = require('fs');
+var path = require('path');
 var Q = require('q');
 var bonjour = require('bonjour')();
 var ip = require('ip');
 var sysIds = {};
-var accessories = [];
+var tvAccessories = [];
 var cachedAccessories = [];
 var controlAccessory;
 
@@ -33,6 +35,7 @@ module.exports = function(homebridge) {
   hap = homebridge.hap;
   Characteristic = homebridge.hap.Characteristic;
   UUIDGen = homebridge.hap.uuid;
+  CachedConfigFile = path.join(homebridge.user.cachedAccessoryPath(), 'homebridge-yamaha-zone-tv.json')
   homebridge.registerPlatform("homebridge-yamaha-zone-tv", "yamaha-zone-tv", YamahaAVRPlatform, true);
 };
 
@@ -46,50 +49,91 @@ function YamahaAVRPlatform(log, config, api) {
   this.maxVolume = config["max_volume"] || 20.0;
   this.disablePartySwitch = config["disable_party_switch"] || false;
   this.disableMainPowerSwitch = config["disable_main_power_switch"] || false;
+  this.radioPresets = config["radio_presets"] || false;
   this.gapVolume = this.maxVolume - this.minVolume;
   this.discoveryTimeout = config["discovery_timeout"] || 10;
   this.zoneControllersOnlyFor = config["zone_controllers_only_for"] || null;
+  
+  try {
+    cachedConfig = JSON.parse(fs.readFileSync(CachedConfigFile));
+  } catch (err) {
+      debug('Cached names file does not exist');
+      cachedConfig = {
+        custom: {
+          disablePartySwitch: undefined,
+          disableMainPowerSwitch: undefined,
+          radioPresets: undefined,
+        },
+        units: {}
+      };  
+  }
 
   this.api.on('didFinishLaunching', this.didFinishLaunching.bind(this));
 }
 
 YamahaAVRPlatform.prototype.configureAccessory = function(accessory) {
-  cachedAccessories.push(accessory)
   debug("configuredAccessory", accessory);
+  
+  var foundDuplicateIndex = cachedAccessories.findIndex(cachedAccessory => cachedAccessory.UUID === accessory.UUID)
+  var foundDuplicate = cachedAccessories.find(cachedAccessory => cachedAccessory.UUID === accessory.UUID)
+  if (foundDuplicate) {
+    this.api.unregisterPlatformAccessories("homebridge-yamaha-zone-tv", "yamaha-zone-tv", [foundDuplicate]);
+    cachedAccessories.splice(foundDuplicateIndex, 1)
+  }
+  cachedAccessories.push(accessory)
+
 };
 
 YamahaAVRPlatform.prototype.didFinishLaunching = function() {
+  debug('didFinishLaunching')
   this.log("Getting Yamaha AVR devices.");
   var that = this;
+
 
   var browser = bonjour.find({
     type: 'http'
   }, setupFromService.bind(this));
 
-  var timer;
-  var timeElapsed = 0;
-  var checkCyclePeriod = 5000;
-
-  // The callback can only be called once...so we'll have to find as many as we can
-  // in a fixed time and then call them in.
-  var timeoutFunction = function() {
-    timeElapsed += checkCyclePeriod;
-    if (timeElapsed > that.discoveryTimeout * 1000) {
-      that.log("Waited " + that.discoveryTimeout + " seconds, stopping discovery.");
-    } else {
-      timer = setTimeout(timeoutFunction, checkCyclePeriod);
-      return;
-    }
-
+  setTimeout(function() {
+    that.log("Waited " + that.discoveryTimeout + " seconds, stopping discovery.");
+  
     browser.stop();
-    that.log("Discovery finished, found " + accessories.length + " Yamaha AVR devices.");
-    that.api.publishExternalAccessories("yamaha-zone-tv", accessories);
+    that.log("Discovery finished, found " + tvAccessories.length + " Yamaha AVR devices.");
+    that.api.publishExternalAccessories("homebridge-yamaha-zone-tv", tvAccessories);
+  
+    debug('PLATFORM - cachedAccessories', cachedAccessories)
+
+    if ( cachedConfig.custom.radioPresets === undefined
+      || cachedConfig.custom.radioPresets !== that.radioPresets 
+      || cachedConfig.custom.disablePartySwitch !== that.disablePartySwitch 
+      || cachedConfig.custom.disableMainPowerSwitch !== that.disableMainPowerSwitch){
+
+        cachedConfig.custom["radioPresets"] = that.radioPresets;
+        cachedConfig.custom["disablePartySwitch"] = that.disablePartySwitch;
+        cachedConfig.custom["disableMainPowerSwitch"] = that.disableMainPowerSwitch;
+  
+        fs.writeFile(CachedConfigFile, JSON.stringify(cachedConfig), (err) => {
+          if (err)
+              debug('Error occured could not write cachedConfig file %s', err);
+        });
+  
+        debug('UNREGISTERING - cachedAccessories')
+        that.api.unregisterPlatformAccessories("homebridge-yamaha-zone-tv", "yamaha-zone-tv", cachedAccessories);
+        cachedAccessories = [];
+    }
 
     if (controlAccessory && !cachedAccessories.find(accessory => accessory.UUID === controlAccessory.UUID)) {
-      that.api.registerPlatformAccessories("yamaha-zone-tv", "yamaha-zone", [controlAccessory]);
+      cachedAccessories.push(controlAccessory)
+      that.api.registerPlatformAccessories("homebridge-yamaha-zone-tv", "yamaha-zone-tv", [controlAccessory]);
     }
-  };
-  timer = setTimeout(timeoutFunction, checkCyclePeriod);
+
+
+    // remove old devices from cache
+    if (!controlAccessory || (controlAccessory && cachedAccessories.find(accessory => accessory.UUID !== controlAccessory.UUID))) {
+      that.api.unregisterPlatformAccessories("homebridge-yamaha-zone-tv", "yamaha-zone-tv", cachedAccessories.filter(accessory => accessory.UUID !== (controlAccessory ? controlAccessory.UUID : 'everything')));
+    }
+
+  }, this.discoveryTimeout * 1000)
 };
 
 function setupFromService(service) {
@@ -121,91 +165,108 @@ function setupFromService(service) {
         sysIds[sysId] = true;
         this.log("Found Yamaha " + sysModel + " - " + sysId + ", \"" + name + "\"");
 
+        if (!cachedConfig.units[sysId])
+          cachedConfig.units[sysId] = {
+            zones: {},
+            inputsNames: {}
+          }
+
         // add discovery of inputs here
         var inputs = []; // used to retrieve available inputs for the detected receiver
         var inputsXML = sysConfig.YAMAHA_AV.System[0].Config[0].Name[0].Input[0];
-        var id = 0;
-        for (var prop in inputsXML) { // iterate through all inputs
-          var input = {};
-          // some of the names returned are not in sync with the names used for setting the input, so they are converted to match
-          if (prop === 'NET_RADIO') input.ConfiguredName = "NET RADIO"
-          else
-          if (prop === 'V_AUX') {
-            input.ConfiguredName = "V-AUX";
-          } else { // None of the inputs use an _ in setting the input, so removing _ from the input names
-            input.ConfiguredName = prop.replace("_", "");
+        
+        // manually add Main Zone Sync as the receiver XML does not have any info on this
+        inputsXML['Main Zone Sync'] = ['Main Zone Sync']
+
+        for (var prop in inputsXML) { // iterate through all inputs          
+
+          var inputName =util.syncName(prop)
+
+          var input = util.getInputConfig(inputName)
+
+          if (cachedConfig.units[sysId].inputsNames[inputName]) {
+            input.ConfiguredName = cachedConfig.units[sysId].inputsNames[inputName];
+            debug('Found cached input name for')
+          } else {
+            input.ConfiguredName = inputsXML[prop][0]
           }
-          input.ConfiguredTitle = inputsXML[prop][0];
-          input.Identifier = id;
-          input.InputDeviceType = 0;
-          input.InputSourceType = 0;
-          if (!inputs.find(function(element) { // only insert if it does not already exist
-              return input.ConfiguredName === element.ConfiguredName;
-            })) {
+          
+          if (util.isUnique(inputs, input.ConfiguredName)) {
             debug(input.ConfiguredName, "is unique");
             inputs.push(input);
-            id++;
-          } else debug(input.ConfiguredName, "already exists");
-        }
-        // manually add Main Zone Sync as the receiver XML does not have any info on this
-        inputs.push({
-          ConfiguredName: 'Main Zone Sync',
-          ConfiguredTitle: 'Main Zone Sync',
-          Identifier: id,
-          InputDeviceType: [0],
-          InputSourceType: [0]
-        });
-        id++;
+          } else 
+            debug(input.ConfiguredName, "already exists");
 
+        }
+        
         // iterate through the feature list of the amp to add more inputs
         var zonesXML = sysConfig.YAMAHA_AV.System[0].Config[0].Feature_Existence[0];
         for (var prop in zonesXML) {
           // Only return inputs that the receiver supports, skip Zone entries and USB since it's already in the input list
           if (!(prop.includes('one')) && !(prop.includes('USB')) && zonesXML[prop].includes('1')) {
-            var input = {};
 
-            // Convert tuner and net radio to make them work
-            if (prop === 'Tuner') prop = "TUNER";
-            if (prop === 'NET_RADIO') prop = "NET RADIO";
-            input.ConfiguredName = prop;
-            input.ConfiguredTitle = prop;
-            input.Identifier = id;
-            input.InputDeviceType = 0;
-            input.InputSourceType = 10; // App
-            if (!inputs.find(function(element) { // only insert if it does not already exist
-                return input.ConfiguredName === element.ConfiguredName;
-              })) {
+            var inputName =util.syncName(prop)
+
+            var input = util.getInputConfig(inputName)
+  
+            if (cachedConfig.units[sysId].inputsNames[inputName]) {
+              input.ConfiguredName = cachedConfig.units[sysId].inputsNames[inputName];
+              debug('Found cached input name for')
+            } else {
+              input.ConfiguredName = inputName
+            }
+            
+            if (util.isUnique(inputs, input.ConfiguredName)) {
               debug(input.ConfiguredName, "is unique");
               inputs.push(input);
-              id++;
-            } else debug(input.ConfiguredName, "already exists");
+            } else 
+              debug(input.ConfiguredName, "already exists");
           }
         }
 
         yamaha.getAvailableZones().then(
           function(zones) {
             if (zones.length > 0) {
-              controlAccessory = new Accessory(name + "C", UUIDGen.generate(name));
+
+              if (!this.disableMainPowerSwitch || !this.disablePartySwitch || this.radioPresets)
+                controlAccessory = new Accessory(name + "C", UUIDGen.generate(sysId));
+              else
+                controlAccessory = null // if there is no need to create an extra switch
+
               for (var zone in zones) {
                 yamaha.getBasicInfo(zones[zone]).then(function(basicInfo) {
                   if (basicInfo.getVolume() !== -999) {
                     yamaha.getZoneConfig(basicInfo.getZone()).then(
                       function(zoneInfo) {
                         if (zoneInfo) {
-                          var z = Object.keys(zoneInfo.YAMAHA_AV)[1];
-                          var zoneName = zoneInfo.YAMAHA_AV[z][0].Config[0].Name[0].Zone[0];
+                          var zoneId = Object.keys(zoneInfo.YAMAHA_AV)[1];
+                          var zoneName = zoneInfo.YAMAHA_AV[zoneId][0].Config[0].Name[0].Zone[0];
                         } else {
+                          var zoneId = "Main_Zone";
                           var zoneName = "Main_Zone";
                         }
+                        
                         if (this.zoneControllersOnlyFor == null || this.zoneControllersOnlyFor.includes(zoneName)) {
-                          this.log("Adding TV Control for", zoneName);
-                          var uuid = UUIDGen.generate(zoneName + "Z" + name);
+                          this.log("Adding TV Control for", zoneId);
+                          var uuid = UUIDGen.generate(zoneId + "Z" + sysId);
+
+                          if (cachedConfig.units[sysId].zones[zoneId])
+                            zoneName = cachedConfig.units[sysId].zones[zoneId].name
+                          else
+                            cachedConfig.units[sysId].zones[zoneId] = { name: zoneName, hiddenInputs: {} }
+                          
                           if (!cachedAccessories.find(accessory => accessory.UUID === uuid)) {
                             var zoneAccessory = new Accessory(zoneName, uuid, hap.Accessory.Categories.AUDIO_RECEIVER);
-                            var accessory = new YamahaZone(this.log, this.config, zoneName, yamaha, sysConfig, z, zoneAccessory, name, inputs, controlAccessory);
+                            var accessory = new YamahaZone(this.log, this.config, zoneName, yamaha, sysConfig, zoneId, zoneAccessory, name, inputs, controlAccessory);
                             accessory.getServices();
-                            accessories.push(zoneAccessory);
+                            tvAccessories.push(zoneAccessory);
                           }
+
+                          fs.writeFile(CachedConfigFile, JSON.stringify(cachedConfig), (err) => {
+                            if (err)
+                                debug('Error occured could not write cachedConfig file %s', err);
+                          });
+
                         }
                       }.bind(this)
                     );
@@ -223,18 +284,20 @@ function setupFromService(service) {
   );
 }
 
-function YamahaZone(log, config, name, yamaha, sysConfig, zone, accessory, unitName, inputs, controlAccessory) {
+function YamahaZone(log, config, name, yamaha, sysConfig, zoneId, accessory, unitName, inputs, controlAccessory) {
   this.log = log;
   this.config = config;
   this.name = name;
   this.yamaha = yamaha;
   this.sysConfig = sysConfig;
-  this.zone = zone;
+  this.sysId = sysConfig.YAMAHA_AV.System[0].Config[0].System_ID[0]
+  this.zone = zoneId;
   this.accessory = accessory;
   this.unitName = unitName;
   this.inputs = inputs;
   this.controlAccessory = controlAccessory;
-
+  this.disablePartySwitch = config["disable_party_switch"] || false;
+  this.disableMainPowerSwitch = config["disable_main_power_switch"] || false;
   this.radioPresets = config["radio_presets"] || false;
   this.presetNum = config["preset_num"] || false;
   this.minVolume = config["min_volume"] || -80.0;
@@ -278,141 +341,152 @@ YamahaZone.prototype = {
       .setCharacteristic(Characteristic.Manufacturer, "yamaha-zone-tv")
       .setCharacteristic(Characteristic.Model, this.sysConfig.YAMAHA_AV.System[0].Config[0].Model_Name[0])
       .setCharacteristic(Characteristic.FirmwareRevision, require('./package.json').version)
-      .setCharacteristic(Characteristic.SerialNumber, this.sysConfig.YAMAHA_AV.System[0].Config[0].System_ID[0]);
+      .setCharacteristic(Characteristic.SerialNumber, this.sysId + '_' + this.zone);
 
     // for main zone Only
     if (this.zone === "Main_Zone") {
 
-      if (!this.disableMainPowerSwitch || !this.disablePartySwitch || this.radioPresets) {
+      if (this.controlAccessory) {
         this.controlAccessory.getService(Service.AccessoryInformation)
         .setCharacteristic(Characteristic.Name, this.unitName)
         .setCharacteristic(Characteristic.Manufacturer, "yamaha-zone-tv")
         .setCharacteristic(Characteristic.Model, this.sysConfig.YAMAHA_AV.System[0].Config[0].Model_Name[0])
         .setCharacteristic(Characteristic.FirmwareRevision, require('./package.json').version)
-        .setCharacteristic(Characteristic.SerialNumber, this.sysConfig.YAMAHA_AV.System[0].Config[0].System_ID[0]);
-      }
+        .setCharacteristic(Characteristic.SerialNumber, this.sysId);
       
-      if (!this.disableMainPowerSwitch) {
-        var mainSwitch = new Service.Switch("Main Power", UUIDGen.generate(this.unitName), this.unitName);
-        mainSwitch
-          .getCharacteristic(Characteristic.On)
-          .on('get', function(callback, context) {
-            yamaha.isOn().then(
-              function(result) {
-                debug("Main Power", result);
+        if (!this.disableMainPowerSwitch) {
+          var mainSwitch = new Service.Switch("Main Power", UUIDGen.generate(this.sysId + 'Main Power'), this.sysId + 'Main Power');
+          mainSwitch
+            .getCharacteristic(Characteristic.On)
+            .on('get', function(callback, context) {
+              yamaha.isOn().then(
+                function(result) {
+                  debug("Main Power", result);
+                  callback(null, result);
+                },
+                function(error) {
+                  callback(error, false);
+                }
+              );
+            })
+            .on('set', function(powerOn, callback) {
+              this.setPlaying(powerOn).then(function() {
+                callback(null, powerOn);
+              }, function(error) {
+                callback(error, !powerOn); // TODO: Actually determine and send real new status.
+              });
+            }.bind(this));
+          mainSwitch.isPrimaryService = true;
+          this.controlAccessory.addService(mainSwitch);
+        }
+        // Party Mode switch
+        if (!this.disablePartySwitch) {
+
+          var partySwitch = new Service.Switch("Party", UUIDGen.generate("Party"), "Party");
+          partySwitch
+            .getCharacteristic(Characteristic.On)
+            .on('get', function(callback) {
+              this.yamaha.isPartyModeEnabled().then(function(result) {
+                debug("getPartySwitch", that.zone, result);
                 callback(null, result);
-              },
-              function(error) {
-                callback(error, false);
+              });
+            }.bind(this))
+            .on('set', function(on, callback) {
+              debug("setPartySwitch", that.zone, on);
+              if (on) {
+                const that = this;
+                this.yamaha.powerOn().then(function() {
+                  that.yamaha.partyModeOn().then(function() {
+                    callback(null, true);
+                  });
+                });
+              } else {
+                this.yamaha.partyModeOff().then(function() {
+                  callback(null, false);
+                });
               }
-            );
-          })
-          .on('set', function(powerOn, callback) {
-            this.setPlaying(powerOn).then(function() {
-              callback(null, powerOn);
-            }, function(error) {
-              callback(error, !powerOn); // TODO: Actually determine and send real new status.
-            });
-          }.bind(this));
-        mainSwitch.isPrimaryService = true;
-        this.controlAccessory.addService(mainSwitch);
-      }
-      // Party Mode switch
-      if (!this.disablePartySwitch) {
+            }.bind(this));
+          this.controlAccessory.addService(partySwitch);
+        }
 
-        var partySwitch = new Service.Switch("Party", UUIDGen.generate("Party"), "Party");
-        partySwitch
-          .getCharacteristic(Characteristic.On)
-          .on('get', function(callback) {
-            this.yamaha.isPartyModeEnabled().then(function(result) {
-              debug("getPartySwitch", that.zone, result);
-              callback(null, result);
-            });
-          }.bind(this))
-          .on('set', function(on, callback) {
-            debug("setPartySwitch", that.zone, on);
-            if (on) {
-              const that = this;
-              this.yamaha.powerOn().then(function() {
-                that.yamaha.partyModeOn().then(function() {
-                  callback(null, true);
-                });
-              });
-            } else {
-              this.yamaha.partyModeOff().then(function() {
-                callback(null, false);
-              });
-            }
-          }.bind(this));
-        this.controlAccessory.addService(partySwitch);
-      }
+        // Radio Preset buttons
 
-      // Radio Preset buttons
+        if (this.radioPresets) {
+          yamaha.getTunerPresetList().then(function(presets) {
+            for (var preset in presets) {
+              this.log("Adding preset %s - %s", preset, presets[preset].value, this.presetNum);
+              if (!this.presetNum) {
+                // preset by frequency
+                var presetSwitch = new Service.Switch(presets[preset].value, UUIDGen.generate(presets[preset].value), presets[preset].value);
+              } else {
+                // preset by button
+                var presetSwitch = new Service.Switch("Preset " + preset, UUIDGen.generate(preset), preset);
+              }
+              presetSwitch.context = {};
 
-      if (this.radioPresets) {
-        yamaha.getTunerPresetList().then(function(presets) {
-          for (var preset in presets) {
-            this.log("Adding preset %s - %s", preset, presets[preset].value, this.presetNum);
-            if (!this.presetNum) {
-              // preset by frequency
-              var presetSwitch = new Service.Switch(presets[preset].value, UUIDGen.generate(presets[preset].value), presets[preset].value);
-            } else {
-              // preset by button
-              var presetSwitch = new Service.Switch("Preset " + preset, UUIDGen.generate(preset), preset);
-            }
-            presetSwitch.context = {};
+              presetSwitch.context.preset = preset;
+              presetSwitch
+                .getCharacteristic(Characteristic.On)
+                .on('get', function(callback, context) {
+                  // debug("getPreset", this);
+                  yamaha.getBasicInfo(that.zone).then(function(basicInfo) {
+                    // debug('YamahaSwitch Is On', basicInfo.isOn()); // True
+                    // debug('YamahaSwitch Input', basicInfo.getCurrentInput()); // Tuner
 
-            presetSwitch.context.preset = preset;
-            presetSwitch
-              .getCharacteristic(Characteristic.On)
-              .on('get', function(callback, context) {
-                // debug("getPreset", this);
-                yamaha.getBasicInfo(that.zone).then(function(basicInfo) {
-                  // debug('YamahaSwitch Is On', basicInfo.isOn()); // True
-                  // debug('YamahaSwitch Input', basicInfo.getCurrentInput()); // Tuner
-
-                  if (basicInfo.isOn() && basicInfo.getCurrentInput() === 'TUNER') {
-                    yamaha.getTunerInfo().then(function(result) {
-                      // console.log( 'TunerInfo', JSON.stringify(result,null, 0));
-                      debug(result.Play_Info[0].Feature_Availability[0]); // Ready
-                      debug(result.Play_Info[0].Search_Mode[0]); // Preset
-                      debug(result.Play_Info[0].Preset[0].Preset_Sel[0]); // #
-                      if (result.Play_Info[0].Feature_Availability[0] === 'Ready' &&
-                        result.Play_Info[0].Search_Mode[0] === 'Preset' &&
-                        result.Play_Info[0].Preset[0].Preset_Sel[0] === this.context.preset) {
-                        callback(null, true);
-                      } else {
-                        callback(null, false);
-                      }
+                    if (basicInfo.isOn() && basicInfo.getCurrentInput() === 'TUNER') {
+                      yamaha.getTunerInfo().then(function(result) {
+                        // console.log( 'TunerInfo', JSON.stringify(result,null, 0));
+                        debug(result.Play_Info[0].Feature_Availability[0]); // Ready
+                        debug(result.Play_Info[0].Search_Mode[0]); // Preset
+                        debug(result.Play_Info[0].Preset[0].Preset_Sel[0]); // #
+                        if (result.Play_Info[0].Feature_Availability[0] === 'Ready' &&
+                          result.Play_Info[0].Search_Mode[0] === 'Preset' &&
+                          result.Play_Info[0].Preset[0].Preset_Sel[0] === this.context.preset) {
+                          callback(null, true);
+                        } else {
+                          callback(null, false);
+                        }
+                      }.bind(this));
+                    } else {
+                      // Off
+                      callback(null, false);
+                    }
+                  }.bind(this), function(error) {
+                    callback(error);
+                  });
+                }.bind(presetSwitch))
+                .on('set', function(powerOn, callback) {
+                  // debug("setPreset", this);
+                  yamaha.setMainInputTo("TUNER").then(function() {
+                    return yamaha.selectTunerPreset(this.context.preset).then(function() {
+                      debug('Tuning radio to preset %s - %s', this.context.preset);
+                      callback(null);
                     }.bind(this));
-                  } else {
-                    // Off
-                    callback(null, false);
-                  }
-                }.bind(this), function(error) {
-                  callback(error);
-                });
-              }.bind(presetSwitch))
-              .on('set', function(powerOn, callback) {
-                // debug("setPreset", this);
-                yamaha.setMainInputTo("TUNER").then(function() {
-                  return yamaha.selectTunerPreset(this.context.preset).then(function() {
-                    debug('Tuning radio to preset %s - %s', this.context.preset, this.displayName);
-                    callback(null);
                   }.bind(this));
-                }.bind(this));
-              }.bind(presetSwitch));
+                }.bind(presetSwitch));
 
-            // debug("Bind", this, presetSwitch);
-            this.controlAccessory.addService(presetSwitch);
-          }
-        }.bind(this)).bind(this);
+              // debug("Bind", this, presetSwitch);
+              this.controlAccessory.addService(presetSwitch);
+            }
+          }.bind(this)).bind(this);
+        }
       }
     }
 
     var zoneService = new Service.Television(this.name);
     debug("TV Zone name:", this.name);
-    zoneService.setCharacteristic(Characteristic.ConfiguredName, this.name);
+    
+    zoneService.getCharacteristic(Characteristic.ConfiguredName)
+      .on('set', (name, callback) => {
+        debug('Setting new ConfiguredName for %s', this.zone )
+        cachedConfig.units[this.sysId].zones[this.zone].name = name
+        fs.writeFile(CachedConfigFile, JSON.stringify(cachedConfig), (err) => {
+          if (err)
+              debug('Error occured could not write cachedConfig file %s', err);
+        });
+        callback()
+      }).updateValue(this.name)
+
     zoneService.getCharacteristic(Characteristic.Active)
       .on('get', function(callback, context) {
         yamaha.isOn(that.zone).then(
@@ -444,7 +518,7 @@ YamahaZone.prototype = {
       // Set identifier for active input
 
       zoneService.getCharacteristic(Characteristic.ActiveIdentifier).updateValue(that.inputs.find(function(input) {
-        return (input.ConfiguredName === basicInfo.getCurrentInput() ? input : false);
+        return (input.NameIdentifier === basicInfo.getCurrentInput() ? input : false);
       }).Identifier);
     });
 
@@ -455,7 +529,7 @@ YamahaZone.prototype = {
         yamaha.getBasicInfo(that.zone).then(function(basicInfo) {
           debug("getActiveIdentifier Input", that.zone, basicInfo.getCurrentInput());
           callback(null, that.inputs.find(function(input) {
-            return (input.ConfiguredName === basicInfo.getCurrentInput() ? input : false);
+            return (input.NameIdentifier === basicInfo.getCurrentInput() ? input : false);
           }).Identifier);
         });
         // callback(null);
@@ -573,30 +647,64 @@ YamahaZone.prototype = {
 
     that.inputs.forEach(function(input) {
       // Don't add Main Zone Sync for the Main zone
-      if (this.zone !== "Main_Zone" || input.ConfiguredName !== "Main Zone Sync") {
+      if (this.zone !== "Main_Zone" || input.NameIdentifier !== "Main Zone Sync") {
         // debug("Adding input", input.ConfiguredName, "for zone", this.name);
-        var inputService = new Service.InputSource(input.ConfiguredName, UUIDGen.generate(this.name + input.ConfiguredName), input.ConfiguredName);
+        var inputService = new Service.InputSource(input.ConfiguredName, UUIDGen.generate(this.zone + input.NameIdentifier), this.zone + input.NameIdentifier);
+
+        inputService.getCharacteristic(Characteristic.ConfiguredName)
+          .on('set', (name, callback) => {
+            debug('Setting new ConfiguredName for Input %s - %s', input.NameIdentifier, name )
+            cachedConfig.units[this.sysId].inputsNames[input.NameIdentifier] = name
+
+            fs.writeFile(CachedConfigFile, JSON.stringify(cachedConfig), (err) => {
+              if (err)
+                  debug('Error occured could not write cachedConfig file %s', err);
+            });
+
+            // update each zone with the new configured input name
+            tvAccessories.forEach(tvAccessory => {
+              if (tvAccessory.UUID !== this.accessory.UUID) {
+                tvAccessory.getService(input.ConfiguredName)
+                  .getCharacteristic(Characteristic.ConfiguredName)
+                  .updateValue(name)
+              }
+            })
+
+            callback()
+          }).updateValue(input.ConfiguredName)
+
 
         inputService
           .setCharacteristic(Characteristic.Identifier, input.Identifier)
-          .setCharacteristic(Characteristic.ConfiguredName, input.ConfiguredTitle) // Use title instead of name
           .setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.CONFIGURED)
           .setCharacteristic(Characteristic.InputSourceType, input.InputSourceType)
+          .setCharacteristic(Characteristic.InputDeviceType, input.InputDeviceType)
           .getCharacteristic(Characteristic.TargetVisibilityState)
-          .on('set', function(newValue, callback) {
-            debug("setTargetVisibilityState => setNewValue: ", that.zone, newValue);
-            inputService.getCharacteristic(Characteristic.CurrentVisibilityState).updateValue(newValue);
-            callback(null);
-          });
+            .on('set', (newValue, callback) => {
+              debug("setTargetVisibilityState => setNewValue: ", that.zone, newValue);
+              inputService.getCharacteristic(Characteristic.CurrentVisibilityState).updateValue(newValue);
+              cachedConfig.units[this.sysId].zones[this.zone].hiddenInputs[input.NameIdentifier] = newValue
+              fs.writeFile(CachedConfigFile, JSON.stringify(cachedConfig), (err) => {
+                if (err)
+                    debug('Error occured could not write cachedConfig file %s', err);
+              });
 
-        // if sourcetype = App or the Title is different than name (custom name is created) make input visible by default
-        if (input.InputSourceType !== 10 /* App */ && (input.ConfiguredName === input.ConfiguredTitle && input.ConfiguredName !== 'Main Zone Sync')) {
-          debug("Making input", input.ConfiguredTitle, "invisible");
+
+              callback(null);
+            });
+
+        // check if VisibilityState is in cache
+        var isHidden = cachedConfig.units[this.sysId].zones[this.zone].hiddenInputs[input.NameIdentifier]
+        // if not in cache and sourcetype = App or the Title is different than name (custom name is created) make input visible by default
+        if (isHidden === undefined && input.InputSourceType !== 10 /* App */ && input.ConfiguredName === input.NameIdentifier && input.ConfiguredName !== 'Main Zone Sync') {
+          debug("Making input", input.NameIdentifier, "invisible");
           inputService.getCharacteristic(Characteristic.CurrentVisibilityState).updateValue(1);
           inputService.getCharacteristic(Characteristic.TargetVisibilityState).updateValue(1);
+        } else if (isHidden !== undefined) {
+          debug('Found input ', input.NameIdentifier, 'VisibilityState in cache - ', (isHidden ? 'hidden' : 'visible'))
+          inputService.getCharacteristic(Characteristic.CurrentVisibilityState).updateValue(isHidden);
+          inputService.getCharacteristic(Characteristic.TargetVisibilityState).updateValue(isHidden);
         }
-
-        // debug("Input service", inputService.displayName, inputService.UUID, inputService.subtype, input.ConfiguredTitle, input.ConfiguredName);
 
         zoneService.addLinkedService(inputService);
         this.accessory.addService(inputService);
@@ -611,13 +719,6 @@ YamahaZone.prototype = {
       .setCharacteristic(Characteristic.VolumeControlType, Characteristic.VolumeControlType.RELATIVE_WITH_CURRENT);
     // .setCharacteristic(Characteristic.Volume, 50);
 
-    yamaha.getBasicInfo(that.zone).then(function(basicInfo) {
-      var v = basicInfo.getVolume() / 10.0;
-      var p = 100 * ((v - that.minVolume) / that.gapVolume);
-      p = p < 0 ? 0 : p > 100 ? 100 : Math.round(p);
-      debug("Got volume percent of " + p + "%", that.zone);
-      speakerService.getCharacteristic(Characteristic.Volume).updateValue(p);
-    });
 
     speakerService.getCharacteristic(Characteristic.Volume)
       .on('get', function(callback) {
@@ -635,23 +736,44 @@ YamahaZone.prototype = {
         callback(null);
       });
 
+    yamaha.getBasicInfo(that.zone).then(function(basicInfo) {
+      var v = basicInfo.getVolume() / 10.0;
+      var p = 100 * ((v - that.minVolume) / that.gapVolume);
+      p = p < 0 ? 0 : p > 100 ? 100 : Math.round(p);
+      debug("Got volume percent of " + p + "%", that.zone);
+      speakerService.getCharacteristic(Characteristic.Volume).updateValue(p);
+    });
 
     speakerService.getCharacteristic(Characteristic.VolumeSelector)
-      .on('set', function(decrement, callback) {
-        if (decrement) {
-          debug("Decrementing Volume by 1 for ", that.zone);
-          yamaha.volumeDown(1, that.zone).then(function(status) {
-            debug("Status", that.zone, status);
-          });
-
-        } else {
-          debug("Incrementing Volume by 1 for ", that.zone);
-          yamaha.volumeUp(1, that.zone).then(function(status) {
-            debug("Status", that.zone, status);
-          });
-        }
+      .on('set', function(newValue, callback) {
+        var volume = speakerService.getCharacteristic(Characteristic.Volume).value;
+        // debug(volume, speakerService.getCharacteristic(Characteristic.Volume));
+        volume = volume + (newValue ? -1 : +1);
+        speakerService.getCharacteristic(Characteristic.Volume).updateValue(volume);
+        var v = ((volume / 100) * that.gapVolume) + that.minVolume;
+        v = Math.round(v) * 10.0;
+        debug("Setting volume to ", that.zone, v / 10);
+        yamaha.setVolumeTo(v, that.zone).then(function(status) {
+          debug("Status", that.zone, status);
+        });
+        debug("set VolumeSelector => setNewValue: ", that.zone, newValue, volume);
         callback(null);
       });
+      // .on('set', function(decrement, callback) {
+      //   if (decrement) {
+      //     debug("Decrementing Volume by 1 for ", that.zone);
+      //     yamaha.volumeDown(1, that.zone).then(function(status) {
+      //       debug("Status", that.zone, status);
+      //     });
+
+      //   } else {
+      //     debug("Incrementing Volume by 1 for ", that.zone);
+      //     yamaha.volumeUp(1, that.zone).then(function(status) {
+      //       debug("Status", that.zone, status);
+      //     });
+      //   }
+      //   callback(null);
+      // });
 
     this.accessory.addService(speakerService);
   }

--- a/index.js
+++ b/index.js
@@ -197,7 +197,7 @@ function setupFromService(service) {
                         if (this.zoneControllersOnlyFor == null || this.zoneControllersOnlyFor.includes(zoneName)) {
                           this.log("Adding TV Control for", zoneName);
                           var uuid = UUIDGen.generate(zoneName + "Z" + name);
-                          var zoneAccessory = new Accessory(zoneName, uuid, hap.Accessory.Categories.TELEVISION);
+                          var zoneAccessory = new Accessory(zoneName, uuid, hap.Accessory.Categories.AUDIO_RECEIVER);
                           var accessory = new YamahaZone(this.log, this.config, zoneName, yamaha, sysConfig, z, zoneAccessory, name, inputs, controlAccessory);
                           accessory.getServices();
                           accessories.push(zoneAccessory);

--- a/lib/util.js
+++ b/lib/util.js
@@ -25,214 +25,219 @@ Characteristic.InputDeviceType.AUDIO_SYSTEM = 5;
 */
 
 // I copied this out of the WebUI for my Receiver
+var id = 40
 
-module.exports = {
+
+const inputsConfigs = module.exports = {
   Inputs: [{
-      ConfiguredName: "TUNER",
+      NameIdentifier: "TUNER",
       Identifier: 0,
-      InputDeviceType: 5,
+      InputDeviceType: 3,
       InputSourceType: 2
     },
     {
-      ConfiguredName: "MULTI CH",
+      NameIdentifier: "MULTI CH",
       Identifier: 1,
       InputDeviceType: 5,
       InputSourceType: 0
     },
     {
-      ConfiguredName: "PHONO",
+      NameIdentifier: "PHONO",
       Identifier: 2,
       InputDeviceType: 5,
-      InputSourceType: 2
+      InputSourceType: 0
     },
     {
-      ConfiguredName: "HDMI1",
+      NameIdentifier: "HDMI1",
       Identifier: 3,
-      InputDeviceType: 5,
+      InputDeviceType: 1,
       InputSourceType: 3
     },
     {
-      ConfiguredName: "HDMI2",
+      NameIdentifier: "HDMI2",
       Identifier: 4,
-      InputDeviceType: 5,
+      InputDeviceType: 1,
       InputSourceType: 3
     },
     {
-      ConfiguredName: "HDMI3",
+      NameIdentifier: "HDMI3",
       Identifier: 5,
-      InputDeviceType: 5,
+      InputDeviceType: 1,
       InputSourceType: 3
     },
     {
-      ConfiguredName: "HDMI4",
+      NameIdentifier: "HDMI4",
       Identifier: 6,
-      InputDeviceType: 5,
+      InputDeviceType: 1,
       InputSourceType: 3
     },
     {
-      ConfiguredName: "HDMI5",
+      NameIdentifier: "HDMI5",
       Identifier: 7,
-      InputDeviceType: 5,
+      InputDeviceType: 1,
       InputSourceType: 3
     },
     {
-      ConfiguredName: "HDMI6",
+      NameIdentifier: "HDMI6",
       Identifier: 8,
-      InputDeviceType: 5,
+      InputDeviceType: 1,
       InputSourceType: 3
     },
     {
-      ConfiguredName: "HDMI7",
+      NameIdentifier: "HDMI7",
       Identifier: 9,
-      InputDeviceType: 5,
+      InputDeviceType: 1,
       InputSourceType: 3
     },
     {
-      ConfiguredName: "AV1",
+      NameIdentifier: "AV1",
       Identifier: 10,
-      InputDeviceType: 5,
-      InputSourceType: 7
+      InputDeviceType: 0,
+      InputSourceType: 0
     },
     {
-      ConfiguredName: "AV2",
+      NameIdentifier: "AV2",
       Identifier: 11,
-      InputDeviceType: 5,
-      InputSourceType: 7
+      InputDeviceType: 0,
+      InputSourceType: 0
     },
     {
-      ConfiguredName: "AV3",
+      NameIdentifier: "AV3",
       Identifier: 12,
-      InputDeviceType: 5,
-      InputSourceType: 7
+      InputDeviceType: 0,
+      InputSourceType: 0
     },
     {
-      ConfiguredName: "AV4",
+      NameIdentifier: "AV4",
       Identifier: 13,
-      InputDeviceType: 5,
-      InputSourceType: 7
+      InputDeviceType: 0,
+      InputSourceType: 0
     },
     {
-      ConfiguredName: "AV5",
+      NameIdentifier: "AV5",
       Identifier: 14,
-      InputDeviceType: 5,
-      InputSourceType: 7
+      InputDeviceType: 0,
+      InputSourceType: 0
     },
     {
-      ConfiguredName: "AV6",
+      NameIdentifier: "AV6",
       Identifier: 15,
-      InputDeviceType: 5,
-      InputSourceType: 7
+      InputDeviceType: 0,
+      InputSourceType: 0
     },
     {
-      ConfiguredName: "AV7",
+      NameIdentifier: "AV7",
       Identifier: 16,
       InputDeviceType: 5,
-      InputSourceType: 7
+      InputSourceType: 0
     },
     {
-      ConfiguredName: "V-AUX",
+      NameIdentifier: "V-AUX",
       Identifier: 17,
       InputDeviceType: 5,
       InputSourceType: 4
     },
     {
-      ConfiguredName: "AUDIO1",
+      NameIdentifier: "AUDIO1",
       Identifier: 18,
-      InputDeviceType: 0,
-      InputSourceType: 3
+      InputDeviceType: 5,
+      InputSourceType: 0
     },
     {
-      ConfiguredName: "AUDIO2",
+      NameIdentifier: "AUDIO2",
       Identifier: 19,
-      InputDeviceType: 1,
-      InputSourceType: 3
+      InputDeviceType: 5,
+      InputSourceType: 0
     },
     {
-      ConfiguredName: "AUDIO3",
+      NameIdentifier: "AUDIO3",
       Identifier: 20,
-      InputDeviceType: 2,
-      InputSourceType: 3
+      InputDeviceType: 5,
+      InputSourceType: 0
     },
     {
-      ConfiguredName: "AUDIO4",
+      NameIdentifier: "AUDIO4",
       Identifier: 21,
-      InputDeviceType: 3,
-      InputSourceType: 3
+      InputDeviceType: 5,
+      InputSourceType: 0
     },
     {
-      ConfiguredName: "USB/NET",
+      NameIdentifier: "USB/NET",
       Identifier: 22,
       InputDeviceType: 5,
       InputSourceType: 9
     },
     {
-      ConfiguredName: "Rhapsody",
+      NameIdentifier: "Rhapsody",
       Identifier: 23,
       InputDeviceType: 5,
       InputSourceType: 10
     },
     {
-      ConfiguredName: "Napster",
+      NameIdentifier: "Napster",
       Identifier: 24,
       InputDeviceType: 5,
       InputSourceType: 10
     },
     {
-      ConfiguredName: "SiriusXM",
+      NameIdentifier: "SiriusXM",
       Identifier: 25,
       InputDeviceType: 5,
       InputSourceType: 10
     },
     {
-      ConfiguredName: "Pandora",
+      NameIdentifier: "Pandora",
       Identifier: 26,
       InputDeviceType: 5,
       InputSourceType: 10
     },
     {
-      ConfiguredName: "Spotify",
+      NameIdentifier: "Spotify",
       Identifier: 27,
-      InputDeviceType: 4,
+      InputDeviceType: 5,
       InputSourceType: 10
     },
     {
-      ConfiguredName: "AirPlay",
+      NameIdentifier: "AirPlay",
       Identifier: 28,
       InputDeviceType: 5,
       InputSourceType: 8
     },
     {
-      ConfiguredName: "SERVER",
+      NameIdentifier: "SERVER",
       Identifier: 29,
       InputDeviceType: 5,
       InputSourceType: 10
     },
     {
-      ConfiguredName: "NET RADIO",
+      NameIdentifier: "NET RADIO",
       Identifier: 30,
       InputDeviceType: 5,
       InputSourceType: 10
     },
     {
-      ConfiguredName: "USB",
+      NameIdentifier: "USB",
       Identifier: 31,
       InputDeviceType: 5,
       InputSourceType: 9
     },
     {
-      ConfiguredName: "iPod (USB)",
+      NameIdentifier: "iPod (USB)",
       Identifier: 32,
       InputDeviceType: 5,
-      InputSourceType: 0
+      InputSourceType: 9
     },
     {
-      ConfiguredName: "Main Zone Sync",
+      NameIdentifier: "Main Zone Sync",
       Identifier: 33,
       InputDeviceType: 5,
       InputSourceType: 10
     }
   ],
-  mapKeyToControl: mapKeyToControl
+  mapKeyToControl: mapKeyToControl,
+  getInputConfig: getInputConfig,
+  syncName: syncName,
+  isUnique: isUnique
 };
 
 var Characteristic = {};
@@ -274,4 +279,38 @@ function mapKeyToControl(key) {
       break;
   }
   return (code);
+}
+
+function getInputConfig(name){
+  var foundInput = inputsConfigs.Inputs.find(input => input.NameIdentifier === name)
+  if (foundInput)
+    return foundInput
+  else {
+    id ++
+    return {
+      NameIdentifier: name,
+      Identifier: id,
+      InputDeviceType: 0,
+      InputSourceType: 0
+    }
+
+  }
+}
+
+function syncName(name) {
+  if (name === 'NET_RADIO') 
+    return "NET RADIO"
+  
+  if (name === 'V_AUX')
+    return "V-AUX";
+
+  if (name === 'Tuner') 
+    return "TUNER";
+    
+  return name.replace("_", "");
+  
+}
+
+function isUnique(inputs, inputName) {
+  return !inputs.find(input => inputName === input.ConfiguredName)
 }


### PR DESCRIPTION
Hi!

As promised, I created a huge PR with a lot of useful changes:

- Add the possibility to **disable party switch or disable main power switch**.
- Changed the accessory category to **AUDIO_RECEIVER** to support the new iOS 14 icon of receiver (you can already see this icon when adding the device).
- **Fixed Volume get function** so HomeKit will be updated with the current Volume when you open the Home app (NOT DOING ANYTHING).
- **Fixed VolumeSelector function** to always increase/decrease value by 1
- **Removed dependency in the receiver/zones names** -  on this version, no UUID is created based on the device or zones names, only by their IDs. This will help to preserve all the settings and setup you did in HomeKit if you decide to change those names in the receiver and restart HomeBridge. **Because of it, users updating to this version will require to re-add the accessories to HomeKit**
- **Fixed registering/unregistering** devices so it won't register the control device everytime you restart homebridge.
- **Cached zones & inputs names** so if you change them in Home app it will keep the name for the next time you restart HomeBridge.
- **Cached inputs visibility state** - if you change the visibility of the inputs it will cache for the next HomeBridge restart.


I'm gonna implement the fan accessory for volume control as an extra in this plugin so it won't be needed to use 2 plugins and the state will update on both at once, but this is it for now...